### PR TITLE
fix: correct typos in comments and CSS property and update github actions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -27,12 +27,12 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install ESLint
         run: |
-          npm install eslint@8.10.0
-          npm install @microsoft/eslint-formatter-sarif@2.1.7
+          npm install eslint@9
+          npm install @microsoft/eslint-formatter-sarif@3
 
       - name: Run ESLint
         run: npx eslint .
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload analysis results to GitHub actions log
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: eslint-results.sarif
           path: eslint-results.sarif

--- a/.github/workflows/html5validator.yml
+++ b/.github/workflows/html5validator.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checks HTML5
       uses: Cyb3r-Jak3/html5validator-action@master
@@ -23,7 +23,7 @@ jobs:
 
     - name: Upload analysis results to GitHub actions log
       if: success() || failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HTML5validator.log
         path: log.log

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'src'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   },
   "homepage": "https://github.com/imolb/pdfhighlighter#readme",
   "devDependencies": {
-    "eslint": "^8.31.0",
-    "eslint-config-standard": "^17.0.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-n": "^15.6.0",
+    "eslint": "^9.0.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-n": "^16.6.0",
     "eslint-plugin-promise": "^6.1.1",
-    "jsdoc": "^4.0.0"
+    "jsdoc": "^4.0.2"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,7 @@
       }
       
       .active {
-        pointer-event: auto;
+        pointer-events: auto;
       }
 
       .inactive {

--- a/src/pdfhighlight.js
+++ b/src/pdfhighlight.js
@@ -25,12 +25,12 @@ function convertToRgb (str) {
 }
 
 /**
- * Computes with of character based on provided font class
+ * Computes width of character based on provided font class
  *
  * @param {string} character - Character to get widths for
  * @param {PDFJsLib.Font} font - font of the found text box
  *
- * @returns {number} Width of character width of given string, null if not found
+ * @returns {number|null} Width of character, null if not found
  */
 function widthOfChar (character, font) {
   for (let idxMap = 0; idxMap < font.toUnicode._map.length; idxMap++) {
@@ -44,12 +44,12 @@ function widthOfChar (character, font) {
 }
 
 /**
- * Computes with of text based on provided font class
+ * Computes width of text based on provided font class
  *
  * @param {string} text - Text to compute widths for
  * @param {PDFJsLib.Font} font - font of the found text box
  *
- * @returns {number} Sum of character width of given string, null if characters not found
+ * @returns {number|null} Sum of character widths, null if any char not found
  */
 function widthOfString (text, font) {
   let sum = 0
@@ -76,7 +76,7 @@ function widthOfString (text, font) {
  * @param {number} positionX - X coordinate of found text box
  * @param {number} width - width of the found text box
  * @param {number} textHeight - height of the text
- * @param {number} pageWidth - widht of the page
+ * @param {number} pageWidth - width of the page
  * @param {PDFJsLib.Font} font - font of the found text box
  *
  * @returns {array} - Returns array with field boxWidth and boxX parameters, where highlight shall be set
@@ -134,11 +134,11 @@ function computeHighlightPosition (searchTerm, searchInsensitive, textBoxStr, hi
       break
     }
     case 'box':
-    // Highlight the full text box wihtin the search term was found
+      // Highlight the full text box within the search term was found
       highlightPos.push({ boxWidth: width, boxX: positionX })
       break
     case 'row':
-    // Highlight the full row of the page
+      // Highlight the full row of the page
       highlightPos.push({ boxWidth: pageWidth, boxX: 0 })
       break
     default:
@@ -311,7 +311,7 @@ function guiProcessed () {
  * Call back function of the generate button in the GUI
  * The function will perform the following steps
  * - Load the PDF document by {@link readHostedFile} or {@link readUploadFile}
- * - Search for the term and highlight the found searc term by {@link searchPage}
+ * - Search for the term and highlight the found search term by {@link searchPage}
  * - Show the result
  *
  * @return {void}
@@ -378,7 +378,7 @@ async function generateOutputPdf () {
     const pdfDoc = await window.PDFLib.PDFDocument.load(fileContent)
 
     // Load the document again via PDF.js which supports search features within the PDF
-    // The fontExtraProperties are needed to have access to the witdth property of the font
+    // The fontExtraProperties are needed to have access to the width property of the font
     const loadingTask = await pdfjsLib.getDocument({ data: fileContent, fontExtraProperties: true })
 
     // Create a new document for purpose of text width computations


### PR DESCRIPTION
- Fix 'with' → 'width' in function documentation (multiple instances)
- Fix 'wihtin' → 'within' in code comment
- Fix 'searc' → 'search' in JSDoc comment
- Fix 'pointer-event' → 'pointer-events' CSS property